### PR TITLE
include <cstdio> and call std::fopen with the proper namespace

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -3,6 +3,7 @@
 
 #include <stdexcept>
 #include <cstring>
+#include <cstdio>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -93,7 +94,7 @@ static FILE *tivtc_fopen(const char *name, const char *mode) {
     } else
         throw TIVTCError("Failed to convert file name to wide char.");
 #else
-    return fopen(name, mode);
+    return std::fopen(name, mode);
 #endif
 }
 


### PR DESCRIPTION
Fixes compilation on FreeBSD.